### PR TITLE
Introduce Bits-Service OCI registry

### DIFF
--- a/scf/README.md
+++ b/scf/README.md
@@ -33,8 +33,16 @@ You are basically two `helm install's` away from deploying `SCF` with `Eirini`. 
       # set to false if you don't want Eirini to create ingress rules for apps
       use_app_ingress: true
 
+      # use Bits-Service as image registry
+      use_bits_service_registry: true
+
     secrets:
       NATS_PASSWORD: changeme
+
+      # when using Bits-Service as image registry:
+      BITS_SERVICE_SECRET: changeme
+      BITS_SERVICE_SIGNING_USER_PASSWORD: changeme
+      BLOBSTORE_PASSWORD: changeme
     ```
 
 1. Deploy SCF by following the steps in [this](https://github.com/SUSE/scf/wiki/How-to-Install-SCF#deploy-using-helm) section. The remainder of that document is optional.

--- a/scf/helm/cf/templates/bits.yaml
+++ b/scf/helm/cf/templates/bits.yaml
@@ -1,0 +1,110 @@
+# ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bits
+data:
+  bits-config-key: |
+    logging:
+      level: debug
+    private_endpoint: "https://bits.{{ .Release.Namespace }}.svc.cluster.local"
+    public_endpoint: "https://bits.{{ index .Values.kube.external_ips 0 }}.nip.io"
+    cert_file: /workspace/jobs/bits-service/certs/tls.crt
+    key_file: /workspace/jobs/bits-service/certs/tls.key
+    port: 6666
+    secret:  {{ .Values.secrets.BITS_SERVICE_SECRET }}
+    skip_cert_verify: true
+    max_body_size: 2M
+    signing_users:
+      - username: admin
+        password:  {{ .Values.secrets.BITS_SERVICE_SIGNING_USER_PASSWORD }}
+    app_stash_config:
+      maximum_size: 512M
+      minimum_size: 64K
+
+    buildpacks:
+      blobstore_type: webdav
+      webdav_config: &webdav_config
+        directory_key: cc-buildpacks
+        private_endpoint: https://blobstore-blobstore.{{ .Release.Namespace }}.svc.cluster.local:4443
+        public_endpoint: https://blobstore.{{ index .Values.kube.external_ips 0 }}.nip.io
+        username: blobstore_user
+        password: {{ .Values.secrets.BLOBSTORE_PASSWORD  }}
+        # TODO: provide proper cert file here
+        ca_cert_path: /workspace/jobs/bits-service/certs/tls.crt
+        # TODO: remove this skip, when we have propert cert file above
+        skip_cert_verify: true
+    droplets:
+      blobstore_type: webdav
+      webdav_config:
+        <<: *webdav_config
+        directory_key: cc-droplets
+    packages:
+      blobstore_type: webdav
+      webdav_config:
+        <<: *webdav_config
+        directory_key: cc-packages
+    app_stash:
+      blobstore_type: webdav
+      webdav_config:
+        <<: *webdav_config
+        directory_key: cc-resources
+
+    enable_registry: true
+
+# Deployment
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: "bits"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: "bits"
+  template:
+    metadata:
+      labels:
+        name: "bits"
+    spec:
+      dnsPolicy: "ClusterFirst"
+      volumes:
+        - name: bits-config
+          configMap:
+            name: "bits"
+            items:
+            - key: bits-config-key
+              path: bits-service.yml
+        - name: bits-cert
+          secret:
+            secretName: private-registry-cert
+      containers:
+      - name: bits
+        image: flintstonecf/bits-service:latest
+        imagePullPolicy: Always
+        restartPolicy: OnFailure
+        ports:
+          - containerPort: 4443
+        volumeMounts:
+        - name: bits-config
+          mountPath: /workspace/jobs/bits-service/config
+        - name: bits-cert
+          mountPath: /workspace/jobs/bits-service/certs
+
+# Service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "bits"
+spec:
+  externalIPs: {{ .Values.kube.external_ips | toJson }}
+  ports:
+    - port: 6666
+      protocol: TCP
+      targetPort: 6666
+      name: bits
+  selector:
+    name: "bits"

--- a/scf/helm/cf/templates/bits.yaml
+++ b/scf/helm/cf/templates/bits.yaml
@@ -15,6 +15,8 @@ data:
     cert_file: /workspace/jobs/bits-service/certs/tls.crt
     key_file: /workspace/jobs/bits-service/certs/tls.key
     port: 6666
+    enable_http: true
+    http_port: 8888
     secret:  {{ .Values.secrets.BITS_SERVICE_SECRET }}
     skip_cert_verify: true
     max_body_size: 2M
@@ -102,13 +104,39 @@ kind: Service
 metadata:
   name: "bits"
 spec:
+{{- if not .Values.opi.use_registry_ingress }}
   externalIPs: {{ .Values.kube.external_ips | toJson }}
+{{- end }}
   ports:
-    - port: 6666
+    - port: {{ if .Values.opi.use_registry_ingress }}8888{{ else }}6666{{ end }}
       protocol: TCP
-      targetPort: 6666
+      targetPort: {{ if .Values.opi.use_registry_ingress }}8888{{ else }}6666{{ end }}
       name: bits
   selector:
     name: "bits"
 
+# Ingress
+{{- if .Values.opi.use_registry_ingress }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bits-registry
+  labels:
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  tls:
+    - hosts:
+      - "registry.{{ .Values.opi.ingress_endpoint }}"
+      secretName: private-registry-cert
+  rules:
+    - host: "registry.{{ .Values.opi.ingress_endpoint }}"
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: bits
+              servicePort: 8888
+{{- end }}
 {{- end }}

--- a/scf/helm/cf/templates/bits.yaml
+++ b/scf/helm/cf/templates/bits.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.opi.use_bits_service_registry }}
+
 # ConfigMap
 ---
 apiVersion: v1
@@ -108,3 +110,5 @@ spec:
       name: bits
   selector:
     name: "bits"
+
+{{- end }}

--- a/scf/helm/cf/templates/eirini.yaml
+++ b/scf/helm/cf/templates/eirini.yaml
@@ -100,7 +100,11 @@ data:
       cf_username: "admin"
       cc_certs_secret_name: "secrets-{{ .Chart.Version }}-{{ .Values.kube.secrets_generation_counter }}"
       cf_password: {{ .Values.secrets.CLUSTER_ADMIN_PASSWORD }}
+      {{- if .Values.opi.use_bits_service_registry }}
       external_eirini_address: registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666
+      {{- else}}
+      external_eirini_address: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}:443"{{ else }}"{{ index .Values.kube.external_ips 0 }}:5800"{{ end }}
+      {{- end}}
       eirini_address: "http://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
       stager_image_tag: {{ .Values.opi.image_tag }}
       use_ingress: {{ .Values.opi.use_app_ingress }}
@@ -200,9 +204,12 @@ spec:
       - name: create-certs
         env:
         - name: REGISTRY
+          {{- if .Values.opi.use_bits_service_registry }}
           value: registry.{{ index .Values.kube.external_ips 0 }}.nip.io
-        # TODO: Use eirini/cert-generate when it is fixed.
-        image: pego/certs-generate
+          {{- else }}
+          value: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}"{{ else }}"{{ index .Values.kube.external_ips 0 }}"{{ end }}
+          {{- end }}
+        image: eirini/certs-generate
         imagePullPolicy: Always
 
 # copy-certs
@@ -230,7 +237,11 @@ spec:
       - name: copy-certs
         env:
         - name: REGISTRY
+          {{- if .Values.opi.use_bits_service_registry }}
           value: registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666
+          {{- else }}
+          value: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}:443"{{ else }}"{{ index .Values.kube.external_ips 0 }}:5800"{{ end }}
+          {{- end}}
         image: eirini/certs-copy:multinode
         volumeMounts:
         - name: host-docker

--- a/scf/helm/cf/templates/eirini.yaml
+++ b/scf/helm/cf/templates/eirini.yaml
@@ -101,7 +101,7 @@ data:
       cc_certs_secret_name: "secrets-{{ .Chart.Version }}-{{ .Values.kube.secrets_generation_counter }}"
       cf_password: {{ .Values.secrets.CLUSTER_ADMIN_PASSWORD }}
       {{- if .Values.opi.use_bits_service_registry }}
-      external_eirini_address: registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666
+      external_eirini_address: {{ if .Values.opi.use_registry_ingress }}"registry.{{ .Values.opi.ingress_endpoint }}:443"{{ else }}"registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666"{{ end }}
       {{- else}}
       external_eirini_address: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}:443"{{ else }}"{{ index .Values.kube.external_ips 0 }}:5800"{{ end }}
       {{- end}}
@@ -205,7 +205,7 @@ spec:
         env:
         - name: REGISTRY
           {{- if .Values.opi.use_bits_service_registry }}
-          value: registry.{{ index .Values.kube.external_ips 0 }}.nip.io
+          value: {{ if .Values.opi.use_registry_ingress }}"registry.{{ .Values.opi.ingress_endpoint }}"{{ else }}"registry.{{ index .Values.kube.external_ips 0 }}.nip.io"{{ end }}
           {{- else }}
           value: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}"{{ else }}"{{ index .Values.kube.external_ips 0 }}"{{ end }}
           {{- end }}
@@ -238,7 +238,7 @@ spec:
         env:
         - name: REGISTRY
           {{- if .Values.opi.use_bits_service_registry }}
-          value: registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666
+          value: {{ if .Values.opi.use_registry_ingress }}"registry.{{ .Values.opi.ingress_endpoint }}:443"{{ else }}"registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666"{{ end }}
           {{- else }}
           value: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}:443"{{ else }}"{{ index .Values.kube.external_ips 0 }}:5800"{{ end }}
           {{- end}}

--- a/scf/helm/cf/templates/eirini.yaml
+++ b/scf/helm/cf/templates/eirini.yaml
@@ -100,7 +100,7 @@ data:
       cf_username: "admin"
       cc_certs_secret_name: "secrets-{{ .Chart.Version }}-{{ .Values.kube.secrets_generation_counter }}"
       cf_password: {{ .Values.secrets.CLUSTER_ADMIN_PASSWORD }}
-      external_eirini_address: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}:443"{{ else }}"{{ index .Values.kube.external_ips 0 }}:5800"{{ end }}
+      external_eirini_address: registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666
       eirini_address: "http://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
       stager_image_tag: {{ .Values.opi.image_tag }}
       use_ingress: {{ .Values.opi.use_app_ingress }}
@@ -200,8 +200,9 @@ spec:
       - name: create-certs
         env:
         - name: REGISTRY
-          value: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}"{{ else }}"{{ index .Values.kube.external_ips 0 }}"{{ end }}
-        image: eirini/certs-generate
+          value: registry.{{ index .Values.kube.external_ips 0 }}.nip.io
+        # TODO: Use eirini/cert-generate when it is fixed.
+        image: pego/certs-generate
         imagePullPolicy: Always
 
 # copy-certs
@@ -229,7 +230,7 @@ spec:
       - name: copy-certs
         env:
         - name: REGISTRY
-          value: {{ if .Values.opi.use_registry_ingress }}"we-love-pandas.{{ .Values.opi.ingress_endpoint }}:443"{{ else }}"{{ index .Values.kube.external_ips 0 }}:5800"{{ end }}
+          value: registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666
         image: eirini/certs-copy:multinode
         volumeMounts:
         - name: host-docker

--- a/scf/helm/cf/values.yaml
+++ b/scf/helm/cf/values.yaml
@@ -1059,6 +1059,9 @@ opi:
   # Change this to force kubernetes pulling the latest image (alternatively delete the corresponding pod)
   version: "0.0.0"
 
+  # This enables/disables the Bits-Service as image registry
+  use_bits_service_registry: false
+
 # The sizing section contains configuration to change each individual instance
 # group. Due to limitations on the allowable names, any dashes ("-") in the
 # instance group names are replaced with underscores ("_").


### PR DESCRIPTION
Hey guys,

This is the helm template we currently use to deploy Bits-Service and use it as OCI image registry. I think we'll need a couple of iterations before this can be merged. E.g. We had to change the `external_eirini_address` to use `.Values.kube.external_ips` instead of the ingress endpoint. Maybe we can figure out a way to avoid this, in case that is preferable.

Curious to get your feedback.

Thanks,
Peter