### PR TITLE
Add loadbalancer config to sample values.yml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -31,3 +31,5 @@ eirini:
   kube:
     external_ips:
     - Should Match:kube.external_ips[0]
+services:
+  loadbalanced: false


### PR DESCRIPTION
The default values.yaml that we tell users to base their values.yaml off doesn't have loadbalancer variable. It is required by anybody trying to deploy on GKE.