### PR TITLE
Introduce configurable blobstore configuration

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -29,7 +29,7 @@ data:
       maximum_size: 512M
       minimum_size: 64K
 
-    {{- if .Values.bits.blobstore_config }}
+    {{- if and (hasKey .Values "bits") (hasKey .Values.bits "blobstore_config") }}
     buildpacks: {{ .Values.bits.blobstore_config.buildpacks | toJson }}
     droplets: {{ .Values.bits.blobstore_config.droplets | toJson }}
     packages: {{ .Values.bits.blobstore_config.packages | toJson }}

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -29,6 +29,12 @@ data:
       maximum_size: 512M
       minimum_size: 64K
 
+    {{- if .Values.bits.blobstore_config }}
+    buildpacks: {{ .Values.bits.blobstore_config.buildpacks | toJson }}
+    droplets: {{ .Values.bits.blobstore_config.droplets | toJson }}
+    packages: {{ .Values.bits.blobstore_config.packages | toJson }}
+    app_stash: {{ .Values.bits.blobstore_config.app_stash | toJson }}
+    {{- else }}
     buildpacks:
       blobstore_type: webdav
       webdav_config: &webdav_config
@@ -60,6 +66,7 @@ data:
       webdav_config:
         <<: *webdav_config
         directory_key: cc-resources
+    {{- end }}
 
     enable_registry: true
 


### PR DESCRIPTION
Add optional blobstore configuration parameter to the `values.yaml` to
override the default `webdav` blobstore configuration.

Example:
```
bits:
  blobstore_config:
    droplets: &droplets_config
      blobstore_type: AWS
      s3_config:
        bucket: your-fancy-bucket-name
        host: s3-endpoint
        access_key_id: <access-id>
        secret_access_key: <access-key>
        region: us-geo
        s3_debug_log_level:
    buildpacks: *droplets_config
    packages: *droplets_config
    app_stash: *droplets_config
```

Signed-off-by: Matthias Diester <matthias.diester@de.ibm.com>

Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

1. Please base your PR off the `develop` branch.
1. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.
1. Please provide automated tests (preferred) or instructions for manually testing your change.
