### PR TITLE
Add registry_endpoint to bits configmap

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -14,6 +14,13 @@ data:
     {{- else }}
     public_endpoint: https://bits.{{ index .Values.kube.external_ips 0 }}.nip.io
     {{- end }}
+    {{- if .Values.opi.use_registry_ingress }}
+    registry_endpoint: "https://registry.{{ .Values.opi.ingress_endpoint }}"
+    {{- else if .Values.services.loadbalanced }}
+    registry_endpoint: "https://registry.{{ index .Values.env.DOMAIN }}"
+    {{- else }}
+    registry_endpoint: "https://registry.{{ index .Values.kube.external_ips 0 }}.nip.io"
+    {{- end }}
     cert_file: /workspace/jobs/bits-service/certs/tls.crt
     key_file: /workspace/jobs/bits-service/certs/tls.key
     port: 6666


### PR DESCRIPTION
Hey guys,

The latest version of the Bits-Service OCI registry requires a `registry_endpoint` to be set in the `bits.yaml` `configmap`.
The `registry_endpoint` is an HTTP virtual host and must match whatever is in `registry_address` in the eirini `configmap`.

Also, it removes the port on the `public_endpoint` as this is not used. The port can be specified in the `Port` property.

This change does all this.

