### PR TITLE
Pin bits-service image tag to 2.25.0-dev.6

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -92,7 +92,7 @@ spec:
             secretName: private-registry-cert
       containers:
       - name: bits
-        image: flintstonecf/bits-service:latest
+        image: flintstonecf/bits-service:2.25.0-dev.6
         imagePullPolicy: Always
         restartPolicy: OnFailure
         ports:


### PR DESCRIPTION
This enables us to introduce a new image that does not have an embedded eirinifs.

So far Bits-Service had the eirinifs baked into the image itself. We'll remove that in future Bits-Service docker images and download it explicitly in an init-container. To avoid breaking everyone else, and until we have made the necessary changes in helm `bits.yaml`, we'll pin the version here.