### PR TITLE
Pin bits-service image tag to 2.25.0-dev.7, containerd support

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -99,7 +99,7 @@ spec:
             secretName: private-registry-cert
       containers:
       - name: bits
-        image: flintstonecf/bits-service:2.25.0-dev.6
+        image: flintstonecf/bits-service:2.25.0-dev.7
         imagePullPolicy: Always
         restartPolicy: OnFailure
         ports:


### PR DESCRIPTION
2.25.0-dev.7 contains the changes made in https://github.com/cloudfoundry-incubator/bits-service/pull/20, i.e. it works with **containerd**.

