### PR TITLE
fix index .Values.env.DOMAIN bug

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -10,7 +10,7 @@ data:
       level: debug
     private_endpoint: "https://bits.{{ .Release.Namespace }}.svc.cluster.local"
     {{- if .Values.services.loadbalanced }}
-    public_endpoint: https://registry.{{ index .Values.env.DOMAIN }}:6666
+    public_endpoint: https://registry.{{ .Values.env.DOMAIN }}:6666
     {{- else }}
     public_endpoint: https://bits.{{ index .Values.kube.external_ips 0 }}.nip.io
     {{- end }}
@@ -35,7 +35,7 @@ data:
         directory_key: cc-buildpacks
         private_endpoint: https://blobstore-blobstore.{{ .Release.Namespace }}.svc.cluster.local:4443
         {{- if .Values.services.loadbalanced }}
-        public_endpoint: https://blobstore.{{ index .Values.env.DOMAIN }}
+        public_endpoint: https://blobstore.{{ .Values.env.DOMAIN }}
         {{- else }}
         public_endpoint: https://blobstore.{{ index .Values.kube.external_ips 0 }}.nip.io
         {{- end }}

--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
       {{- if .Values.opi.use_registry_ingress }}
       registry_address: "registry.{{ .Values.opi.ingress_endpoint }}:443"
       {{- else if .Values.services.loadbalanced }}
-      registry_address: "registry.{{ index .Values.env.DOMAIN }}:6666"
+      registry_address: "registry.{{ .Values.env.DOMAIN }}:6666"
       {{- else }}
       registry_address: "registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666"
       {{- end }}

--- a/helm/eirini/templates/daemonset.yaml
+++ b/helm/eirini/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
           {{- if .Values.opi.use_registry_ingress }}
           value: "registry.{{ .Values.opi.ingress_endpoint }}:443"
           {{- else if .Values.services.loadbalanced }}
-          value: "registry.{{ index .Values.env.DOMAIN }}:6666"
+          value: "registry.{{ .Values.env.DOMAIN }}:6666"
           {{- else }}
           value: "registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666"
           {{- end }}

--- a/helm/eirini/templates/job-create-certs.yaml
+++ b/helm/eirini/templates/job-create-certs.yaml
@@ -17,7 +17,7 @@ spec:
           {{- if .Values.opi.use_registry_ingress }}
           value: "registry.{{ .Values.opi.ingress_endpoint }}"
           {{- else if .Values.services.loadbalanced }}
-          value: "registry.{{ index .Values.env.DOMAIN }}"
+          value: "registry.{{ .Values.env.DOMAIN }}"
           {{- else }}
           value: "registry.{{ index .Values.kube.external_ips 0 }}.nip.io"
           {{- end }}


### PR DESCRIPTION
`.Values.env.DOMAIN` is a string not an array, so it shouldn't be used with index in the templates. 
Using
```
service: 
  loadbalanced: true 
```
results in an error when deploying `eirini/cf`:

```
Error: render error in "cf/charts/eirini/templates/daemonset.yaml": template: cf/charts/eirini/templates/daemonset.yaml:28:30: executing "cf/charts/eirini/templates/daemonset.yaml" at <index .Values.env.DO...>: error calling index: index of untyped nil
```

This fixes it.