### PR TITLE
Allow providing custom certificate for bits-service registry ingress

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -89,7 +89,7 @@ spec:
               path: bits-service.yml
         - name: bits-cert
           secret:
-            secretName: private-registry-cert
+            secretName: {{- if and (and .Values.opi.use_registry_ingress (hasKey .Values.opi "ingress_secret")) .Values.opi.ingress_secret }} {{.Values.opi.ingress_secret}}{{else}} private-registry-cert{{end}}
       containers:
       - name: bits
         image: flintstonecf/bits-service:latest
@@ -139,7 +139,8 @@ spec:
   tls:
     - hosts:
       - "registry.{{ .Values.opi.ingress_endpoint }}"
-      secretName: private-registry-cert
+      secretName: {{- if and (hasKey .Values.opi "ingress_secret") .Values.opi.ingress_secret }} {{.Values.opi.ingress_secret}}{{else}} private-registry-cert{{end}}
+
   rules:
     - host: "registry.{{ .Values.opi.ingress_endpoint }}"
       http:

--- a/helm/eirini/templates/daemonset.yaml
+++ b/helm/eirini/templates/daemonset.yaml
@@ -1,4 +1,4 @@
----
+{{- if not ( and ( and .Values.opi.use_registry_ingress ( hasKey .Values.opi "ingress_secret" ) )  .Values.opi.ingress_secret ) }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -33,3 +33,4 @@ spec:
         volumeMounts:
         - name: host-docker
           mountPath: /workspace/docker
+{{end}}

--- a/helm/eirini/templates/job-create-certs.yaml
+++ b/helm/eirini/templates/job-create-certs.yaml
@@ -1,4 +1,4 @@
----
+{{- if not ( and ( and .Values.opi.use_registry_ingress ( hasKey .Values.opi "ingress_secret" ) )  .Values.opi.ingress_secret ) }}
 kind: Job
 apiVersion: batch/v1
 metadata:
@@ -23,3 +23,4 @@ spec:
           {{- end }}
         image: eirini/certs-generate:{{ .Values.opi.image_tag }}
         imagePullPolicy: Always
+{{end}}


### PR DESCRIPTION
This include:
  - If use_registry_ingress is set to true, and the ingress_cert is
    provided: 1) don't generate `private-registry-cert`, 2) don't deploy cert-copier daemonSetsa and 3) use the provided cert instead.
  - Otherwise, generate and copy self-signed certificate.


Currently, Eirini generate self-signed certificates for accessing the bits-service registry, the current setup, doesn't allow the deployer to provide publicly signed certs, and thus this PR. In psudo-code, this PR does:
```
IF not (use_registry_ingress is enabled and ingress_signed_certs is exist
   and ingress_signed_certs is not empty) THEN
   generate self-signed certificate
   generate certs-copier DaemonSets
   use the generated self-signed certs
ELSE
    use ingress_signed_certs
FI
```