### PR TITLE
Separate the eirini rootfs from bits-service oci-image

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -110,9 +110,13 @@ spec:
         - name: bits-cert
           secret:
             secretName: private-registry-cert
+        - name: bits-assets
+          hostPath:
+            path: /bits/assets/
+            type: DirectoryOrCreate
       containers:
       - name: bits
-        image: flintstonecf/bits-service:2.25.0-dev.7
+        image: flintstonecf/bits-service:latest
         imagePullPolicy: Always
         restartPolicy: OnFailure
         ports:
@@ -122,6 +126,16 @@ spec:
           mountPath: /workspace/jobs/bits-service/config
         - name: bits-cert
           mountPath: /workspace/jobs/bits-service/certs
+        - name: bits-assets
+          mountPath: /assets/
+      initContainers:
+      - name: "download-eirini-rootfs"
+        image: flintstonecf/eirinifs-downloader:latest
+        command: ["/bin/sh", "-c", "./eirini-rootfs-downloader.sh"]
+        volumeMounts:
+        - name: bits-assets
+          mountPath: /assets/
+        restartPolicy: "OnFailure"
 
 # Service
 ---


### PR DESCRIPTION
We introduce a separation of bits-service oci-image and eirini rootfs.
The bits-service pod deployment does now use a init container to download
the latest eirini rootfs from https://github.com/cloudfoundry-incubator/eirinifs/release.
With this is bits-service and eirini rootfs loosely coupled.

[#160890265]

Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

1. Please base your PR off the `develop` branch.
1. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.
1. Please provide automated tests (preferred) or instructions for manually testing your change.
Behaviour does not change. Verification: bits-service pod is successful deployed.
