### PR TITLE
Separate the eirini rootfs from bits-service oci-image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@
 
 # ignore side effects of GOPATH
 bin/
+pkg/
 src/
 !src/code.cloudfoundry.org/eirini
+
+# Binaries for docker
+docker/opi/opi
+docker/rootfs-patcher/rootfs-patcher

--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ This is a `helm` release for Project [Eirini](https://code.cloudfoundry.org/eiri
 
 1. Export the Registry certificate in the `BITS_TLS_KEY` and `BITS_TLS_CRT` environment variables. (see [Certificates](#Certificates))
 
+1. Set the environemnt varialbe `EIRINI_ROOTFS_VERSION`. This will donwload the mentioned version of `eirinifs.tar`. (see [eirinifs releases](https://github.com/cloudfoundry-incubator/eirinifs/releases))
 1. Install CF:
 
     ```bash
-    helm install eirini/cf --namespace scf --name scf --values <your-values.yaml> --set "secrets.UAA_CA_CERT=${CA_CERT}" --set "eirini.secrets.BITS_TLS_KEY=${BITS_TLS_KEY}" --set "eirini.secrets.BITS_TLS_CRT=${BITS_TLS_CRT}"
+    helm install eirini/cf --namespace scf --name scf --values <your-values.yaml> --set "secrets.UAA_CA_CERT=${CA_CERT}" --set "eirini.secrets.BITS_TLS_KEY=${BITS_TLS_KEY}" --set "eirini.secrets.BITS_TLS_CRT=${BITS_TLS_CRT}" --set "eirini.EIRINI_ROOTFS_VERSION=${EIRINI_ROOTFS_VERSION}"
     ```
 
 1. Use the following command to verify that every CF control plane pod is `running` and `ready`:

--- a/docker/generate-docker-image.sh
+++ b/docker/generate-docker-image.sh
@@ -16,12 +16,10 @@ main(){
 
 build_opi(){
   GOPATH="$BASEDIR" GOOS=linux CGO_ENABLED=0 go build -a -o "$DOCKERDIR/opi/opi" code.cloudfoundry.org/eirini/cmd/opi
-  verify_exit_code $? "Failed to build eirini"
 }
 
 build_rootfs_patcher() {
   GOPATH="$BASEDIR" GOOS=linux CGO_ENABLED=0 go build -a -o "$DOCKERDIR/rootfs-patcher/rootfs-patcher" code.cloudfoundry.org/eirini/cmd/rootfs-patcher
-  verify_exit_code $? "Failed to build rootfs-patcher"
 }
 
 create_docker_images() {
@@ -37,19 +35,12 @@ create_image() {
 
   echo "Creating $image_name docker image..."
   pushd "$path" || exit
-    docker build . -t "${image_name}:$TAG"
-    verify_exit_code $? "Failed to create $image_name docker image"
+    if ! docker build . -t "${image_name}:$TAG"; then
+      echo "Failed to create $image_name docker image"
+      exit 1
+    fi
   popd || exit
   echo "$image_name docker image created!"
-}
-
-verify_exit_code() {
-    local exit_code=$1
-    local error_msg=$2
-    if [ "$exit_code" -ne 0 ]; then
-        echo "$error_msg"
-        exit 1
-    fi
 }
 
 main

--- a/docker/rootfs-patcher/Dockerfile
+++ b/docker/rootfs-patcher/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+
+COPY rootfs-patcher /usr/local/bin/rootfs-patcher

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -110,9 +110,13 @@ spec:
         - name: bits-cert
           secret:
             secretName: private-registry-cert
+        - name: bits-assets
+          hostPath:
+            path: /bits/assets/
+            type: DirectoryOrCreate
       containers:
       - name: bits
-        image: flintstonecf/bits-service:2.25.0-dev.7
+        image: flintstonecf/bits-service:latest
         imagePullPolicy: Always
         restartPolicy: OnFailure
         ports:
@@ -122,6 +126,16 @@ spec:
           mountPath: /workspace/jobs/bits-service/config
         - name: bits-cert
           mountPath: /workspace/jobs/bits-service/certs
+        - name: bits-assets
+          mountPath: /assets/
+      initContainers:
+      - name: "download-eirini-rootfs"
+        image: flintstonecf/eirinifs-downloader:latest
+        command: ["/bin/sh", "-c", "./eirini-rootfs-downloader.sh"]
+        volumeMounts:
+        - name: bits-assets
+          mountPath: /assets/
+        restartPolicy: "OnFailure"
 
 # Service
 ---

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -131,6 +131,9 @@ spec:
       initContainers:
       - name: "download-eirini-rootfs"
         image: flintstonecf/eirinifs-downloader:latest
+        env:
+        - name: EIRINI_ROOTFS_VERSION
+          value: {{ .Values.EIRINI_ROOTFS_VERSION }}
         command: ["/bin/sh", "-c", "./eirini-rootfs-downloader.sh"]
         volumeMounts:
         - name: bits-assets

--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -28,3 +28,4 @@ data:
       cc_cert_path: "/workspace/jobs/opi/secrets/cc.crt"
       cc_key_path: "/workspace/jobs/opi/secrets/cc.key"
       cc_ca_path: "/workspace/jobs/opi/secrets/cc.ca"
+      rootfs_version: {{ .Values.opi.rootfs_version }}

--- a/helm/eirini/templates/rootfs-patcher.yml
+++ b/helm/eirini/templates/rootfs-patcher.yml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+  name: rootfs-patcher
+spec:
+  template:
+    spec:
+      containers:
+      - name: patch
+        command:
+        - rootfs-patcher
+        - --namespace=eirini
+        - --rootfs-version={{ .Values.opi.rootfs_version }}
+        image: eirini/rootfs-patcher:{{ .Values.opi.image_tag }}
+        imagePullPolicy: IfNotPresent
+      restartPolicy: Never
+      serviceAccount: opi
+      serviceAccountName: opi

--- a/helm/eirini/templates/rootfs-patcher.yml
+++ b/helm/eirini/templates/rootfs-patcher.yml
@@ -12,8 +12,9 @@ spec:
       - name: patch
         command:
         - rootfs-patcher
-        - --namespace=eirini
+        - --namespace={{ .Values.opi.namespace }}
         - --rootfs-version={{ .Values.opi.rootfs_version }}
+        - --timeout={{ .Values.opi.rootfs_patcher_timeout }}
         image: eirini/rootfs-patcher:{{ .Values.opi.image_tag }}
         imagePullPolicy: IfNotPresent
       restartPolicy: Never

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -9,6 +9,7 @@ opi:
   image_tag: latest
   stager_image: eirini/recipe
   rootfs_version: 24.0.0
+  rootfs_patcher_timeout: 1h
 
 kube:
   external_ips: []

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -28,3 +28,4 @@ env:
   # Base domain of the SCF cluster.
   # Example: "my-scf-cluster.com"
   DOMAIN: ~
+EIRINI_ROOTFS_VERSION: 

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -9,7 +9,7 @@ opi:
   image_tag: latest
   stager_image: eirini/recipe
   rootfs_version: 24.0.0
-  rootfs_patcher_timeout: 1h
+  rootfs_patcher_timeout: -1
 
 kube:
   external_ips: []

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -8,6 +8,7 @@ opi:
   version: 0.0.0
   image_tag: latest
   stager_image: eirini/recipe
+  rootfs_version: 24.0.0
 
 kube:
   external_ips: []


### PR DESCRIPTION
We introduce a separation of bits-service oci-image and eirini rootfs.
The bits-service pod deployment does now use a init container to download
the latest eirini rootfs from https://github.com/cloudfoundry-incubator/eirinifs/release.
With this is bits-service and eirini rootfs loosely coupled.

[#160890265]

Signed-off-by: Norman Sutorius <norman.sutorius@de.ibm.com>
Signed-off-by: Tobias Zipfel <tobias.zipfel@de.ibm.com>
Signed-off-by: Kiran Jain <kiran.jain2@ibm.com>

Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

1. Please base your PR off the `develop` branch.
1. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.
1. Please provide automated tests (preferred) or instructions for manually testing your change.
