### PR TITLE
Gitignore GOPATH side effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .DS_Store
 /helm/*/charts/
+
+# ignore side effects of GOPATH
+bin/
+src/
+!src/code.cloudfoundry.org/eirini


### PR DESCRIPTION
When developing in src/code.cloudfoundry.org/eirini,
'go get's will install binaries and packages in the eirini-release
directory.

This commit updates the .gitignore s.t. any side effects of running go
commands are ignored.

