### PR TITLE
Remove restart policy from bits pod

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -114,7 +114,6 @@ spec:
       - name: bits
         image: flintstonecf/bits-service:2.25.0-dev.7
         imagePullPolicy: Always
-        restartPolicy: OnFailure
         ports:
           - containerPort: 4443
         volumeMounts:


### PR DESCRIPTION
Helm ignores it, but if I do template and then do `kubectl apply` I can see the issue.
