### PR TITLE
Separate the eirini rootfs from bits-service oci-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ This is a `helm` release for Project [Eirini](https://code.cloudfoundry.org/eiri
 
 1. Export the Registry certificate in the `BITS_TLS_KEY` and `BITS_TLS_CRT` environment variables. (see [Certificates](#Certificates))
 
+1. Set the environemnt varialbe `EIRINI_ROOTFS_VERSION`. This will donwload the mentioned version of `eirinifs.tar`. (see [eirinifs releases](https://github.com/cloudfoundry-incubator/eirinifs/releases))
 1. Install CF:
 
     ```bash
-    helm install eirini/cf --namespace scf --name scf --values <your-values.yaml> --set "secrets.UAA_CA_CERT=${CA_CERT}" --set "eirini.secrets.BITS_TLS_KEY=${BITS_TLS_KEY}" --set "eirini.secrets.BITS_TLS_CRT=${BITS_TLS_CRT}"
+    helm install eirini/cf --namespace scf --name scf --values <your-values.yaml> --set "secrets.UAA_CA_CERT=${CA_CERT}" --set "eirini.secrets.BITS_TLS_KEY=${BITS_TLS_KEY}" --set "eirini.secrets.BITS_TLS_CRT=${BITS_TLS_CRT}" --set "eirini.EIRINI_ROOTFS_VERSION=${EIRINI_ROOTFS_VERSION}"
     ```
 
 1. Use the following command to verify that every CF control plane pod is `running` and `ready`:

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -110,9 +110,13 @@ spec:
         - name: bits-cert
           secret:
             secretName: private-registry-cert
+        - name: bits-assets
+          hostPath:
+            path: /bits/assets/
+            type: DirectoryOrCreate
       containers:
       - name: bits
-        image: flintstonecf/bits-service:2.25.0-dev.7
+        image: flintstonecf/bits-service:latest
         imagePullPolicy: Always
         restartPolicy: OnFailure
         ports:
@@ -122,6 +126,16 @@ spec:
           mountPath: /workspace/jobs/bits-service/config
         - name: bits-cert
           mountPath: /workspace/jobs/bits-service/certs
+        - name: bits-assets
+          mountPath: /assets/
+      initContainers:
+      - name: "download-eirini-rootfs"
+        image: flintstonecf/eirinifs-downloader:latest
+        command: ["/bin/sh", "-c", "./eirini-rootfs-downloader.sh"]
+        volumeMounts:
+        - name: bits-assets
+          mountPath: /assets/
+        restartPolicy: "OnFailure"
 
 # Service
 ---

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -131,6 +131,9 @@ spec:
       initContainers:
       - name: "download-eirini-rootfs"
         image: flintstonecf/eirinifs-downloader:latest
+        env:
+        - name: EIRINI_ROOTFS_VERSION
+          value: {{ .Values.EIRINI_ROOTFS_VERSION }}
         command: ["/bin/sh", "-c", "./eirini-rootfs-downloader.sh"]
         volumeMounts:
         - name: bits-assets

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -28,3 +28,4 @@ env:
   # Base domain of the SCF cluster.
   # Example: "my-scf-cluster.com"
   DOMAIN: ~
+EIRINI_ROOTFS_VERSION: 


### PR DESCRIPTION
We introduce a separation of bits-service oci-image and eirini rootfs.
The bits-service pod deployment does now use a init container to download
the specified version of eirini rootfs via environment variable.

[#160890265]
[#164168224]

Signed-off-by: Norman Sutorius norman.sutorius@de.ibm.com
Signed-off-by: Tobias Zipfel tobias.zipfel@de.ibm.com
Signed-off-by: Kiran Jain kiran.jain2@ibm.com