### PR TITLE
Fix containerPort for bits-service

### DIFF
--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -116,7 +116,7 @@ spec:
         imagePullPolicy: Always
         restartPolicy: OnFailure
         ports:
-          - containerPort: 4443
+          - containerPort: 8888
         volumeMounts:
         - name: bits-config
           mountPath: /workspace/jobs/bits-service/config


### PR DESCRIPTION
Hi,

I just found that bats-service exposed as 8888 but containerPort used 4443 which was not matched. It that correct?
