### PR TITLE
[WIP] add support for cert-manager and external-dns

### DIFF
--- a/helm/cf/templates/diego-ssh.yaml
+++ b/helm/cf/templates/diego-ssh.yaml
@@ -419,6 +419,10 @@ items:
   kind: "Service"
   metadata:
     name: "diego-ssh-ssh-proxy-public"
+    annotations:
+    {{- if .Values.services.externalDNS }}
+      external-dns.alpha.kubernetes.io/hostname: ssh.{{ .Values.env.DOMAIN }}
+    {{- end }}
     labels:
       app.kubernetes.io/component: "diego-ssh-ssh-proxy-public"
       skiff-role-name: "diego-ssh-ssh-proxy-public"

--- a/helm/cf/templates/router.yaml
+++ b/helm/cf/templates/router.yaml
@@ -471,6 +471,11 @@ items:
   kind: "Service"
   metadata:
     name: "router-gorouter-public"
+    annotations:
+    {{- if .Values.services.externalDNS }}
+      external-dns.alpha.kubernetes.io/hostname: "*.{{ .Values.env.DOMAIN }},{{ .Values.env.DOMAIN }}"
+    {{- end }}
+
     labels:
       app.kubernetes.io/component: "router-gorouter-public"
       skiff-role-name: "router-gorouter-public"

--- a/helm/cf/templates/tcp-router.yaml
+++ b/helm/cf/templates/tcp-router.yaml
@@ -371,6 +371,10 @@ items:
   kind: "Service"
   metadata:
     name: "tcp-router-tcp-router-public"
+    annotations:
+    {{- if .Values.services.externalDNS }}
+      external-dns.alpha.kubernetes.io/hostname: tcp.{{ .Values.env.DOMAIN }}
+    {{- end }}
     labels:
       app.kubernetes.io/component: "tcp-router-tcp-router-public"
       skiff-role-name: "tcp-router-tcp-router-public"

--- a/helm/eirini/templates/bits-certificate.yaml
+++ b/helm/eirini/templates/bits-certificate.yaml
@@ -1,3 +1,11 @@
+{{- if not .Values.bits.useExistingSecret }}
+{{- if not hasKey .Values.secrets "BITS_TLS_CRT" }}
+_needsTlsCrt: {{ fail "secrets.BITS_TLS_CRT must be set" }}
+{{- end }}
+{{- if not hasKey .Values.secrets "BITS_TLS_KEY" }}
+_needsTlsKey: {{ fail "secrets.BITS_TLS_KEY must be set" }}
+{{- end }}
+
 # Certificate
 ---
 apiVersion: v1
@@ -8,3 +16,4 @@ kind: Secret
 metadata:
   name: private-registry-cert
 type: Opaque
+{{- end }}

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -145,6 +145,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "bits"
+  annotations:
+{{- if .Values.services.externalDNS }}
+    external-dns.alpha.kubernetes.io/hostname: registry.{{ .Values.env.DOMAIN }}
+{{- end }}
 spec:
 {{- if and (not .Values.opi.use_registry_ingress) (not .Values.services.loadbalanced) }}
   externalIPs: {{ .Values.kube.external_ips | toJson }}

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -28,6 +28,7 @@ scf:
 
 services:
   loadbalanced: false
+  externalDNS: false
 
 secrets:
   BITS_SERVICE_SECRET: secret
@@ -39,3 +40,7 @@ env:
   # Example: "my-scf-cluster.com"
   DOMAIN: ~
 
+bits:
+  # If set to true, must provide a pre-existing secret
+  # named `private-registry-cert`
+  useExistingSecret: false

--- a/helm/uaa/templates/uaa.yaml
+++ b/helm/uaa/templates/uaa.yaml
@@ -439,6 +439,10 @@ items:
   kind: "Service"
   metadata:
     name: "uaa-uaa-public"
+    annotations:
+    {{- if .Values.services.externalDNS }}
+      external-dns.alpha.kubernetes.io/hostname: "uaa.{{ .Values.env.DOMAIN }},*.uaa.{{ .Values.env.DOMAIN }}"
+    {{- end }}
     labels:
       app.kubernetes.io/component: "uaa-uaa-public"
       skiff-role-name: "uaa-uaa-public"


### PR DESCRIPTION
This shows adding the correct annotations to utilize the [external-dns](https://github.com/kubernetes-incubator/external-dns) controller to register DNS for the various components as well as using an externally (cert-manager) provided secret for registry TLS certs.