### PR TITLE
use emtpyDir instead of hostDir for better compatibility

### DIFF
--- a/helm/eirini/Chart.yaml
+++ b/helm/eirini/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.3.0"
 description: A Helm chart for CloudFoundry/Eirini
 name: eirini
-version: 0.0.0-dev
+version: 0.0.1-dev

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -111,7 +111,7 @@ spec:
           secret:
             secretName: private-registry-cert
         - name: bits-assets
-          hostPath:
+          emptyDir:
             path: /bits/assets/
             type: DirectoryOrCreate
       containers:

--- a/helm/eirini/templates/bits.yaml
+++ b/helm/eirini/templates/bits.yaml
@@ -111,9 +111,7 @@ spec:
           secret:
             secretName: private-registry-cert
         - name: bits-assets
-          emptyDir:
-            path: /bits/assets/
-            type: DirectoryOrCreate
+          emptyDir: {}
       containers:
       - name: bits
         image: flintstonecf/bits-service:2.26.0-dev.8


### PR DESCRIPTION
For some more context, reference [this slack conversation](https://cloudfoundry.slack.com/archives/C0BNGJY0G/p1560230966001700):

The use of `hostPath` for the `/bits/assets/` path in the bits-service Deployment causes compatibility issues in clusters (e.g. GKE) where the pod doesn't have write access to the host root filesystem.  Using emtpyDir works around this issue.

The same chart change was pull-requested in the bit-service-release repo via https://github.com/cloudfoundry-incubator/bits-service-release/pull/30
