### PR TITLE
Make smuggler wait for secrets to be generated

### DIFF
--- a/helm/eirini/templates/job-secret-smuggler.yaml
+++ b/helm/eirini/templates/job-secret-smuggler.yaml
@@ -30,6 +30,12 @@ spec:
           {{- else }}
           value: "https://registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666"
           {{- end }}
+        # This is to ensure the job starting only after the secrets are generated. The environment variable itself is not in use.
+        - name: INTERNAL_CA_CERT
+          valueFrom:
+            secretKeyRef:
+              name: secrets-{{ .Values.scf.version }}-{{ .Values.scf.secrets_generation_counter }}
+              key: internal-ca-cert
         volumeMounts:
           - name: bits-config
             mountPath: /config


### PR DESCRIPTION
Without this change secret-smuggler fails if backoffLimit exceeds the limit which is 6 by default.

Before the fix:
```
NAME                            READY   STATUS                  RESTARTS   AGE
...
secret-generation-1-drxqp       0/1     Completed               0          8m26s
secret-smuggler-bhl8z           0/1     CrashLoopBackOff        4          8m26s
...
```
After the fix (note the 3rd column):
```
NAME                            READY   STATUS      RESTARTS   AGE
...
secret-generation-1-rrvsr       0/1     Completed   0          24m
secret-smuggler-7l9nl           0/1     Completed   0          24m
...
```