### PR TITLE
Make eirini work with rbac

### DIFF
--- a/helm/eirini/templates/namespace.yaml
+++ b/helm/eirini/templates/namespace.yaml
@@ -4,3 +4,18 @@ kind: Namespace
 metadata:
   name: {{ .Values.opi.namespace }}
 
+{{- if and (eq (printf "%s" .Values.kube.auth) "rbac") (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eirini-nonprivileged
+  namespace: {{ .Values.opi.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fissile.SanitizeName" (printf "%s-cluster-role-nonprivileged" .Release.Namespace) }}
+subjects:
+- kind: ServiceAccount
+  name: default
+{{- end }}

--- a/helm/eirini/templates/namespace.yaml
+++ b/helm/eirini/templates/namespace.yaml
@@ -7,15 +7,83 @@ metadata:
 {{- if and (eq (printf "%s" .Values.kube.auth) "rbac") (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.opi.namespace }}-restricted-role
+  namespace: {{ .Values.opi.namespace }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ .Values.opi.namespace }}-restricted-psp
+
+---
+# Bind to the default service account
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: eirini-nonprivileged
+  name: {{ .Values.opi.namespace }}-restricted-rolebinding
   namespace: {{ .Values.opi.namespace }}
 roleRef:
+  kind: Role
+  name: {{ .Values.opi.namespace }}-restricted-role
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "fissile.SanitizeName" (printf "%s-cluster-role-nonprivileged" .Release.Namespace) }}
 subjects:
 - kind: ServiceAccount
   name: default
+  namespace: {{ .Values.opi.namespace }}
+
+---
+# Based on https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/restricted-psp.yaml
+# See also: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#example
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.opi.namespace }}-restricted-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    #apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    #apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    #- 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    #rule: 'MustRunAsNonRoot'
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
 {{- end }}

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -20,6 +20,7 @@ opi:
     uploader_image: eirini/recipe-uploader
     uploader_image_tag: 0.2.0
 kube:
+  auth: "rbac"
   external_ips: []
 
 scf:

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@ env:
   UAA_PORT: 2793
 
 kube:
-  auth: rbac
+  auth: &auth rbac
   external_ips: &external_ips
   - <worker-node-ip>
   storage_class:
@@ -39,6 +39,7 @@ eirini:
     BITS_SERVICE_SIGNING_USER_PASSWORD: REPLACE
 
   kube:
+    auth: *auth
     external_ips: *external_ips
  
 bits:


### PR DESCRIPTION
Bind the default service account of `eirini` namespace to a non-privileged cluster role so that pods can be successfully created when rbac is enabled.