### PR TITLE
Standardizes the Ingress TLS configuration with other Stable helm charts

### DIFF
--- a/helm/uaa/templates/ingress.yaml
+++ b/helm/uaa/templates/ingress.yaml
@@ -1,27 +1,4 @@
 {{- if .Values.ingress.enabled -}}
----
-# The certificate and key for the TLS secret are passed through ingress.tls.crt and ingress.tls.key
-# respectively. If the operator does not provide these values at installation time, the TLS secret
-# will contain empty values. The standard behaviour for NGINX ingress controller is to provide a
-# fake certificate instead. It is useful only for testing and development. It is expected that for
-# production use the operator will provide these values.
-apiVersion: "v1"
-kind: "Secret"
-type: kubernetes.io/tls
-metadata:
-  name: "ingress-tls"
-  namespace: {{ .Release.Namespace | quote }}
-  labels:
-    app.kubernetes.io/component: "ingress-tls"
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
-data:
-  tls.crt: {{ .Values.ingress.tls.crt | default "" | b64enc | quote }}
-  tls.key: {{ .Values.ingress.tls.key | default "" | b64enc | quote }}
----
 apiVersion: "extensions/v1beta1"
 kind: "Ingress"
 metadata:
@@ -49,11 +26,6 @@ metadata:
     app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
     helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
 spec:
-  tls:
-  - secretName: "ingress-tls"
-    hosts:
-    - "*.uaa.{{ .Values.env.DOMAIN }}"
-    - "uaa.{{ .Values.env.DOMAIN }}"
   rules:
     - host: "*.uaa.{{ .Values.env.DOMAIN }}"
       http:
@@ -69,4 +41,6 @@ spec:
             backend:
               serviceName: "uaa-uaa"
               servicePort: 2793
+  tls:
+{{ toYaml .Values.ingress.tls | indent 2 }}
 {{- end }}

--- a/helm/uaa/values.yaml
+++ b/helm/uaa/values.yaml
@@ -253,14 +253,22 @@ sizing:
 
 enable: {}
 ingress:
-  # ingress.annotations allows specifying custom ingress annotations that gets
-  # merged to the default annotations.
-  annotations: {}
-
-  # ingress.enabled enables ingress support - working ingress controller
-  # necessary.
+  ## Enable Ingress
+  ##
   enabled: false
 
-  # ingress.tls.crt and ingress.tls.key, when specified, are used by the TLS
-  # secret for the Ingress resource.
+  ## Annotations to be added to the web ingress.
+  ## Example:
+  ##   kubernetes.io/ingress.class: nginx
+  ##   kubernetes.io/tls-acme: 'true'
+  ##
+  annotations: {}
+
+  ## TLS configuration.
+  ## Secrets must be manually created in the namespace.
+  ## Example:
+  ##   - secretName: concourse-web-tls
+  ##     hosts:
+  ##       - concourse.domain.com
+  ##
   tls: {}


### PR DESCRIPTION
The current helm chart only enables TLS configuration via a Secret that gets populated by static values in the helm chart. This does not match the experience in other helm charts such as the [Concourse helm chart](https://github.com/helm/charts/blob/master/stable/concourse/values.yaml), where you only provide a secret location and hostnames.

This PR updates the `hosts` and `tls` sections of the ingress to make them more configurable.