### PR TITLE
Also use configured namespace for adapter access

### DIFF
--- a/helm/eirini/templates/networkpolicy.yml
+++ b/helm/eirini/templates/networkpolicy.yml
@@ -17,7 +17,7 @@ spec:
           app.kubernetes.io/component: router
     - namespaceSelector:
         matchLabels:
-          name: scf
+          name: {{ .Release.Namespace }}
       podSelector:
         matchLabels:
           app.kubernetes.io/component: adapter


### PR DESCRIPTION
Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

1. Please base your PR off the `develop` branch.
[x]
2. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.

Replace hardcoded value for namespace (`scf`) with the same variable used for the router.

3. Please provide automated tests (preferred) or instructions for manually testing your change.

Network access from adapter should now also work in case the default `scf` namespace is not used.