### PR TITLE
[bug/136] remove hard coded scf namespace

### DIFF
--- a/helm/eirini/templates/rootfs-patcher.yml
+++ b/helm/eirini/templates/rootfs-patcher.yml
@@ -15,7 +15,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /bits-waiter
-        - --namespace=scf
+        - --namespace={{ .Release.Namespace }}
         - --timeout={{ .Values.opi.rootfs_patcher_timeout }}
       containers:
       - name: patch


### PR DESCRIPTION
This fixes #136 where the namespace is hard-coded for `scf` 

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

1. Please base your PR off the `develop` branch.
1. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.
1. Please provide automated tests (preferred) or instructions for manually testing your change.
