### PR TITLE
Add missing steps CertManager instructions

### DIFF
--- a/docs/gke.md
+++ b/docs/gke.md
@@ -91,8 +91,9 @@ Deploy [CertManager](https://hub.helm.sh/charts/jetstack/cert-manager).
 The documentation below is valid only for cert-manager v0.11.
 
 ```
+kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml --validate=false 
 helm repo add jetstack https://charts.jetstack.io
-helm install jetstack/cert-manager --version v0.11.0
+helm install --namespace cert-manager jetstack/cert-manager --version v0.11.0
 ```
 
 ### Create a certificate issuer


### PR DESCRIPTION
The steps listed to install CertManager v0.11.0 are missing some vital steps from the instructions listed at https://hub.helm.sh/charts/jetstack/cert-manager/v0.11.0

Specifically:

1.  The cert-manager CRDs must be installed before installing the Helm cert-manager chart
1.  cert-manager must be installed into the `--namespace cert-manager` namespace for following "Create a certificate issuer" instructions to work

Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

1. Please base your PR off the `develop` branch.
1. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.
1. Please provide automated tests (preferred) or instructions for manually testing your change.
