### PR TITLE
Remove external ip from eirini svc

### DIFF
--- a/helm/eirini/templates/service.yaml
+++ b/helm/eirini/templates/service.yaml
@@ -4,9 +4,6 @@ kind: Service
 metadata:
   name: "eirini-opi"
 spec:
-{{- if not .Values.opi.use_registry_ingress }}
-  externalIPs: {{ .Values.kube.external_ips | toJson }}
-{{- end }}
   ports:
     - port: 8085
       protocol: TCP


### PR DESCRIPTION
Remove external ip for service that is accessible internally.
No need for automated testing.

Pair w/ @alex-slynko

We need it for CF on K8s artifact.