### PR TITLE
Ensure all Eirini templates are namespaced

### DIFF
--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "eirini"
+  namespace: {{ .Release.Namespace }}
 data:
   opi.yml: |
     opi:

--- a/helm/eirini/templates/deployment.yaml
+++ b/helm/eirini/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "eirini"
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/events.yaml
+++ b/helm/eirini/templates/events.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "eirini-events"
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/fluentd-configmap.yaml
+++ b/helm/eirini/templates/fluentd-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: fluentd-conf
+  namespace: {{ .Release.Namespace }}
 data:
   fluentd-conf: |
     <match fluent.**>

--- a/helm/eirini/templates/fluentd-daemonset.yaml
+++ b/helm/eirini/templates/fluentd-daemonset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: loggregator-fluentd
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/job-secret-smuggler.yaml
+++ b/helm/eirini/templates/job-secret-smuggler.yaml
@@ -4,6 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: secret-smuggler-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     spec:

--- a/helm/eirini/templates/metrics.yaml
+++ b/helm/eirini/templates/metrics.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "eirini-metrics"
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/rootfs-patcher.yml
+++ b/helm/eirini/templates/rootfs-patcher.yml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "rootfs-patcher-{{ .Values.global.rootfs_version }}-{{ .Release.Revision }}"
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     spec:

--- a/helm/eirini/templates/routing.yaml
+++ b/helm/eirini/templates/routing.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "eirini-routing"
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/service.yaml
+++ b/helm/eirini/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "eirini-opi"
+  namespace: {{ .Release.Namespace }}
 spec:
 {{- if not .Values.opi.use_registry_ingress }}
   externalIPs: {{ .Values.kube.external_ips | toJson }}


### PR DESCRIPTION
When rendering the Eirini Helm chart, we should allow the templates to be rendered for a particular namespace. Most of the templates were supporting, but a few were not, so we are ensuring they all can now.

FWIW, we are using Helm 3 (and `helm template`) and needed to add this to use Helm 3:
`version.BuildInfo{Version:"v3.0.2", GitCommit:"19e47ee3283ae98139d98460de796c1be1e3975f", GitTreeState:"clean", GoVersion:"go1.13.5"}`

Can test by running `helm template --namespace foobar` and ensure the appropriate resources are placed into the `foobar` namespace

@acosta11 & @jspawar & @alex-slynko 
