### PR TITLE
feat: Support arbitrary labels and annotations for all eirini deployment objects

### DIFF
--- a/helm/eirini/templates/deployment.yaml
+++ b/helm/eirini/templates/deployment.yaml
@@ -13,9 +13,13 @@ spec:
       labels:
         name: "eirini"
         eirinifs_version: "{{  .Values.global.rootfs_version  }}"
+{{- if .Values.global.labels }}
 {{ toYaml .Values.global.labels | indent 8 }}
+{{- end }}
+{{- if .Values.global.annotations }}
       annotations:
 {{ toYaml .Values.global.annotations | indent 8 }}
+{{- end }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "opi"

--- a/helm/eirini/templates/deployment.yaml
+++ b/helm/eirini/templates/deployment.yaml
@@ -4,6 +4,14 @@ kind: Deployment
 metadata:
   name: "eirini"
   namespace: {{ .Release.Namespace }}
+{{- if .Values.global.labels }}
+  labels:
+{{ toYaml .Values.global.labels | indent 4 }}
+{{- end }}
+{{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/deployment.yaml
+++ b/helm/eirini/templates/deployment.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         name: "eirini"
         eirinifs_version: "{{  .Values.global.rootfs_version  }}"
+{{ toYaml .Values.global.labels | indent 8 }}
+      annotations:
+{{ toYaml .Values.global.annotations | indent 8 }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "opi"

--- a/helm/eirini/templates/events.yaml
+++ b/helm/eirini/templates/events.yaml
@@ -12,6 +12,9 @@ spec:
     metadata:
       labels:
         name: "eirini-events"
+{{ toYaml .Values.global.labels | indent 8 }}
+      annotations:
+{{ toYaml .Values.global.annotations | indent 8 }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-events"

--- a/helm/eirini/templates/events.yaml
+++ b/helm/eirini/templates/events.yaml
@@ -12,9 +12,13 @@ spec:
     metadata:
       labels:
         name: "eirini-events"
+{{- if .Values.global.labels }}
 {{ toYaml .Values.global.labels | indent 8 }}
+{{- end }}
+{{- if .Values.global.annotations }}
       annotations:
 {{ toYaml .Values.global.annotations | indent 8 }}
+{{- end }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-events"

--- a/helm/eirini/templates/events.yaml
+++ b/helm/eirini/templates/events.yaml
@@ -4,6 +4,14 @@ kind: Deployment
 metadata:
   name: "eirini-events"
   namespace: {{ .Release.Namespace }}
+{{- if .Values.global.labels }}
+  labels:
+{{ toYaml .Values.global.labels | indent 4 }}
+{{- end }}
+{{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/metrics.yaml
+++ b/helm/eirini/templates/metrics.yaml
@@ -4,6 +4,14 @@ kind: Deployment
 metadata:
   name: "eirini-metrics"
   namespace: {{ .Release.Namespace }}
+{{- if .Values.global.labels }}
+  labels:
+{{ toYaml .Values.global.labels | indent 4 }}
+{{- end }}
+{{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/metrics.yaml
+++ b/helm/eirini/templates/metrics.yaml
@@ -12,6 +12,9 @@ spec:
     metadata:
       labels:
         name: "eirini-metrics"
+{{ toYaml .Values.global.labels | indent 8 }}
+      annotations:
+{{ toYaml .Values.global.annotations | indent 8 }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-metrics"

--- a/helm/eirini/templates/metrics.yaml
+++ b/helm/eirini/templates/metrics.yaml
@@ -12,9 +12,13 @@ spec:
     metadata:
       labels:
         name: "eirini-metrics"
+{{- if .Values.global.labels }}
 {{ toYaml .Values.global.labels | indent 8 }}
+{{- end }}
+{{- if .Values.global.annotations }}
       annotations:
 {{ toYaml .Values.global.annotations | indent 8 }}
+{{- end }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-metrics"

--- a/helm/eirini/templates/routing.yaml
+++ b/helm/eirini/templates/routing.yaml
@@ -12,9 +12,13 @@ spec:
     metadata:
       labels:
         name: "eirini-routing"
+{{- if .Values.global.labels }}
 {{ toYaml .Values.global.labels | indent 8 }}
+{{- end }}
+{{- if .Values.global.annotations }}
       annotations:
 {{ toYaml .Values.global.annotations | indent 8 }}
+{{- end }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-routing"

--- a/helm/eirini/templates/routing.yaml
+++ b/helm/eirini/templates/routing.yaml
@@ -4,6 +4,14 @@ kind: Deployment
 metadata:
   name: "eirini-routing"
   namespace: {{ .Release.Namespace }}
+{{- if .Values.global.labels }}
+  labels:
+{{ toYaml .Values.global.labels | indent 4 }}
+{{- end }}
+{{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/templates/routing.yaml
+++ b/helm/eirini/templates/routing.yaml
@@ -12,6 +12,9 @@ spec:
     metadata:
       labels:
         name: "eirini-routing"
+{{ toYaml .Values.global.labels | indent 8 }}
+      annotations:
+{{ toYaml .Values.global.annotations | indent 8 }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-routing"

--- a/helm/eirini/templates/staging-reporter.yaml
+++ b/helm/eirini/templates/staging-reporter.yaml
@@ -13,9 +13,13 @@ spec:
     metadata:
       labels:
         name: "eirini-staging-reporter"
+{{- if .Values.global.labels }}
 {{ toYaml .Values.global.labels | indent 8 }}
+{{- end }}
+{{- if .Values.global.annotations }}
       annotations:
 {{ toYaml .Values.global.annotations | indent 8 }}
+{{- end }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-staging-reporter"

--- a/helm/eirini/templates/staging-reporter.yaml
+++ b/helm/eirini/templates/staging-reporter.yaml
@@ -13,6 +13,9 @@ spec:
     metadata:
       labels:
         name: "eirini-staging-reporter"
+{{ toYaml .Values.global.labels | indent 8 }}
+      annotations:
+{{ toYaml .Values.global.annotations | indent 8 }}
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-staging-reporter"

--- a/helm/eirini/templates/staging-reporter.yaml
+++ b/helm/eirini/templates/staging-reporter.yaml
@@ -5,6 +5,14 @@ kind: Deployment
 metadata:
   name: "eirini-staging-reporter"
   namespace: {{ .Release.Namespace }}
+{{- if .Values.global.labels }}
+  labels:
+{{ toYaml .Values.global.labels | indent 4 }}
+{{- end }}
+{{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -117,3 +117,5 @@ kube:
 
 global:
   rootfs_version: v75.0.0
+  label: {}
+  annotations: {}


### PR DESCRIPTION
See ticket https://github.com/cloudfoundry-incubator/kubecf/issues/795

The feature is needed to set/control annotations for quarks operator restart behavior, and for identification labels, when used as part of a larger system, i.e. kubecf.

- Extended values.yaml with keys for user labels and annotations,
  plus defaults (no user labels, no user annotations).
- Interpolate the new keys into the proper place of the deployments
  (spec.template.metadata).

Note: The user labels and annotations are shared among the deployment objects of eirini.

The change was manually tested using the `helm template` command and a custom additional values.yaml providing required values and some user-specified labels and annotations. The result was inspected to properly contain these labels and annotations.

```
% pwd
(...)/eirini-release--ak/helm

% cat ../../x.yaml
# Fakes for required values.
kube:
  external_ips:
  - 10.10.0.1
# User-specified labels, annotations
global:
  labels:
    hello: kubecf_795
  annotations:
    hello: kubecf_795

% helm template foo eirini --values ../../x.yaml | less
# look for 795.
```
