### PR TITLE
Add the LRP CRD and the LRP Controller deployment templates

### DIFF
--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -81,3 +81,9 @@ data:
     cc_cert_path: "/etc/eirini/secrets/cc.crt"
     cc_key_path: "/etc/eirini/secrets/cc.key"
     ca_path: "/etc/eirini/secrets/cc.ca"
+  lrp-controller.yml: |
+    app_namespace: {{ .Values.opi.namespace }}
+    eirini_uri: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
+    eirini_cert_path: "/etc/eirini/secrets/eirini-client.crt"
+    eirini_key_path: "/etc/eirini/secrets/eirini-client.key"
+    ca_path: "/etc/eirini/secrets/eirini-client.ca"

--- a/helm/eirini/templates/lrp-controller-pod-security-policy.yaml
+++ b/helm/eirini/templates/lrp-controller-pod-security-policy.yaml
@@ -1,49 +1,40 @@
-{{- if .Values.opi.staging.enable }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: eirini-staging-reporter
+  name: lrp-controller
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  name: eirini-staging-reporter
-  namespace: {{ .Values.opi.namespace }}
+  name: lrp-controller-cluster-role
 rules:
 - apiGroups:
-  - ""
+  - eirini.cloudfoundry.org
   resources:
-  - pods
+  - lrps
   verbs:
-  - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
   - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: eirini-staging-reporter
-  namespace: {{ .Values.opi.namespace }}
+  name: lrp-controller-cluster-rolebinding
 roleRef:
-  kind: Role
-  name: eirini-staging-reporter
+  kind: ClusterRole
+  name: lrp-controller-cluster-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: eirini-staging-reporter
+  name: lrp-controller
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: eirini-staging-reporter-psp
+  name: lrp-controller-role
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
@@ -53,26 +44,26 @@ rules:
   verbs:
   - use
   resourceNames:
-  - eirini-staging-reporter
+  - eirini-lrp-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: eirini-staging-reporter-psp
+  name: lrp-controller-rolebinding
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: eirini-staging-reporter-psp
+  name: lrp-controller-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: eirini-staging-reporter
+  name: lrp-controller
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: eirini-staging-reporter
+  name: eirini-lrp-controller
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
@@ -84,7 +75,6 @@ spec:
   volumes:
     - 'configMap'
     - 'secret'
-    - 'projected'
   hostNetwork: false
   hostIPC: false
   hostPID: false
@@ -106,4 +96,3 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
-{{- end }}

--- a/helm/eirini/templates/lrp-controller.yaml
+++ b/helm/eirini/templates/lrp-controller.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.opi.lrpController.enable }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eirini-lrp-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      name: eirini-lrp-controller
+  template:
+    metadata:
+      labels:
+        name: eirini-lrp-controller
+    spec:
+      dnsPolicy: ClusterFirst
+      serviceAccountName: lrp-controller
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: lrp-controller
+        {{- if .Values.opi.lrp_controller_image }}
+        image: {{ .Values.opi.lrp_controller_image }}:{{ .Values.opi.lrp_controller_image_tag }}
+        {{- else }}
+        image: eirini/lrp-controller@{{ .Files.Get "versions/lrp-controller" }}
+        {{- end }}
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 15m
+            memory: 15Mi
+        volumeMounts:
+        - name: config-map-volume
+          mountPath: /etc/eirini/config
+        - name: cf-secrets
+          mountPath: /etc/eirini/secrets
+      volumes:
+        - name: config-map-volume
+          configMap:
+            name: "eirini"
+            items:
+            - key: lrp-controller.yml
+              path: lrp-controller.yml
+        - name: cf-secrets
+          secret:
+            secretName: "{{ .Values.opi.lrpController.tls.secretName }}"
+            items:
+            - key: "{{ .Values.opi.lrpController.tls.certPath }}"
+              path: eirini-client.crt
+            - key: "{{ .Values.opi.lrpController.tls.keyPath }}"
+              path: eirini-client.key
+            - key: "{{ .Values.opi.lrpController.tls.caPath }}"
+              path: eirini-client.ca
+{{- end }}

--- a/helm/eirini/templates/lrp-crd.yaml
+++ b/helm/eirini/templates/lrp-crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: lrps.eirini.cloudfoundry.org
+spec:
+  group: eirini.cloudfoundry.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                guid:
+                  type: string
+                version:
+                  type: string
+                processGUID:
+                  type: string
+                processType:
+                  type: string
+                appGUID:
+                  type: string
+                appName:
+                  type: string
+                spaceGUID:
+                  type: string
+                spaceName:
+                  type: string
+                orgGUID:
+                  type: string
+                orgName:
+                  type: string
+                placementTags:
+                  type: array
+                  items:
+                    type: string
+                ports:
+                  type: array
+                  items:
+                    type: integer
+                    format: int32
+                routes:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        hostname:
+                          type: string
+                        port:
+                          type: integer
+                environment:
+                  type: object
+                  additionalProperties:
+                    type: string
+                egressRules:
+                  type: array
+                  items:
+                    type: string
+                instances:
+                  type: integer
+                lastUpdated:
+                  type: string
+                healthCheckType:
+                  type: string
+                healthCheckHTTPEndpoint:
+                  type: string
+                healthCheckTimeoutMs:
+                  type: integer
+                  format: uint32
+                startTimeoutMs:
+                  type: integer
+                  format: uint32
+                memoryMB:
+                  type: integer
+                  format: int64
+                diskMB:
+                  type: integer
+                  format: int64
+                cpuWeight:
+                  type: integer
+                  format: uint8
+                volumeMounts:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      volumeID:
+                        type: string
+                      mountDir:
+                        type: string
+                lifecycle:
+                  type: object
+                  maxProperties: 1
+                  properties:
+                    docker:
+                      type: object
+                      properties:
+                        image:
+                          type: string
+                        command:
+                          type: array
+                          items:
+                            type: string
+                        registryUsername:
+                          type: string
+                        registryPassword:
+                          type: string
+                          format: password
+                    buildpack:
+                      type: object
+                      properties:
+                        dropletHash:
+                          type: string
+                        dropletGUID:
+                          type: string
+                        startCommand:
+                          type: string
+                userDefinedAnnotations:
+                  type: object
+                  additionalProperties:
+                    type: string
+            status:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                instances:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      since:
+                        type: integer
+                        format: uint64
+                      index:
+                        type: integer
+                        format: uint32
+                      state:
+                        type: string
+                        enum:
+                        - Pending
+                        - Running
+                        - Failed
+                        default: Pending
+                      exitStatus:
+                        type: integer
+                        format: uint32
+                      exitReason:
+                        type: string
+                      crashCount:
+                        type: integer
+                        format: uint64
+                      crashTimestamp:
+                        type: integer
+                        format: uint64
+      subresources:
+        status: {}
+  scope: Namespaced
+  names:
+    plural: lrps
+    singular: lrp
+    kind: LRP
+    shortNames:
+      - lrp

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -109,6 +109,14 @@ opi:
         certPath: "cc-server-crt"
         caPath: "internal-ca-cert"
 
+  lrpController:
+    enable: false
+    tls:
+      secretName: "secrets-2.16.4-2"
+      certPath: "eirini-client-crt"
+      keyPath: "eirini-client-crt-key"
+      caPath: "internal-ca-cert"
+
   kubecf:
     enable: false
 


### PR DESCRIPTION
Note: The LRP Controller is currently disabled (`enable:false` in values.yml) so it shouldn't break anything in CI when this is merged. When we merge https://github.com/cloudfoundry-incubator/eirini/pull/97 and update our CI we can flip it to `true`.