### PR TITLE
Make the eirini<=>api URL more configurable

### DIFF
--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -70,7 +70,7 @@ data:
     loggregator_ca_path: "/etc/eirini/secrets/doppler.ca"
   events.yml: |
     app_namespace: {{ .Values.opi.namespace }}
-    cc_internal_api: "https://{{ .Values.opi.cc_api.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9023"
+    cc_internal_api: "{{ .Values.opi.cc_api.protocol}}://{{ .Values.opi.cc_api.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.opi.cc_api.port}}"
     cc_cert_path: "/etc/eirini/secrets/cc.crt"
     cc_key_path: "/etc/eirini/secrets/cc.key"
     cc_ca_path: "/etc/eirini/secrets/cc.ca"

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -17,6 +17,8 @@ opi:
 
   cc_api:
     serviceName: "api"
+    protocol: https
+    port: 9023
 
   tls:
     opiCapiClient:


### PR DESCRIPTION
cloudfoundry-for-kubernetes (cf-for-k8s) is using istio so
the URLs can be open and istio will handle encryption automatically

The defaults we've added maintain status quo, but it's easier
to configure this URL now.

CF relint story link:
[#172615287](https://www.pivotaltracker.com/story/show/172615287)

Co-authored-by: Gary Liu <galiu@pivotal.io>

Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

1. Please base your PR off the `develop` branch. - done

1. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.
- The CF relint team is currently using a ytt hack to have eirini send crash events to capi using http on port 80. We'd prefer to be able to set these via config variables. This PR leaves their default values as https on port 9023 (status quo).

1. Please provide automated tests (preferred) or instructions for manually testing your change.
Only manual tests right now.
We pushed the CF CATS catnip app and curled it on the `/sigterm/KILL`  endpoint.
Before this change, no crash events were observed running `cf events catnip`.
After this change, they are observed.