### PR TITLE
Make the eirini<=>api URL more configurable

### DIFF
--- a/helm/eirini/templates/configmap.yaml
+++ b/helm/eirini/templates/configmap.yaml
@@ -73,7 +73,7 @@ data:
     loggregator_ca_path: "/etc/eirini/secrets/doppler.ca"
   events.yml: |
     app_namespace: {{ .Values.opi.namespace }}
-    cc_internal_api: "https://{{ .Values.opi.cc_api.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9023"
+    cc_internal_api: "{{ .Values.opi.cc_api.protocol}}://{{ .Values.opi.cc_api.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.opi.cc_api.port}}"
     cc_tls_disabled: {{ .Values.opi.cc_api.tls_disabled }}
     {{- if not .Values.opi.cc_api.tls_disabled }}
     cc_cert_path: "/etc/eirini/secrets/cc.crt"

--- a/helm/eirini/values.yaml
+++ b/helm/eirini/values.yaml
@@ -18,6 +18,8 @@ opi:
   cc_api:
     serviceName: "api"
     tls_disabled: false
+    protocol: https
+    port: 9023
 
   tls:
     opiCapiClient:


### PR DESCRIPTION
cloudfoundry-for-kubernetes (cf-for-k8s) is using istio so the URLs can be open and istio will handle encryption automatically

The defaults we've added maintain status quo, but it's easier to configure this URL now.

CF relint story link:
[#172615287](https://www.pivotaltracker.com/story/show/172615287)

Redo of PR #169 to deal with CLA hassles