### PR TITLE
Set memory and cpu requests and limit values for all containers

### DIFF
--- a/helm/eirini/templates/deployment.yaml
+++ b/helm/eirini/templates/deployment.yaml
@@ -79,3 +79,6 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi

--- a/helm/eirini/templates/eirini-controller.yml
+++ b/helm/eirini/templates/eirini-controller.yml
@@ -30,6 +30,9 @@ spec:
           requests:
             cpu: 15m
             memory: 15Mi
+          limits:
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: config-map-volume
           mountPath: /etc/eirini/config

--- a/helm/eirini/templates/events.yaml
+++ b/helm/eirini/templates/events.yaml
@@ -60,4 +60,7 @@ spec:
           requests:
             cpu: 15m
             memory: 15Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
 {{- end }}

--- a/helm/eirini/templates/task-reporter.yaml
+++ b/helm/eirini/templates/task-reporter.yaml
@@ -30,6 +30,9 @@ spec:
           requests:
             cpu: 15m
             memory: 15Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
         volumeMounts:
         - name: config-map-volume
           mountPath: /etc/eirini/config


### PR DESCRIPTION
Cf-for-K8s is currently working on a scaling and Quality of Service (QoS) set of stories.

We are targeting 1.0 to be configured out-of-the-box as a "developer" edition aimed at those users who want to kick the tires. As part of this, we would like to set limits on mem/cpu. 

Since a "developer" edition may not be preferred by everyone, we want each component to be configurable to scale both horizontally (replicas) and vertically (mem/cpu). This will also allow users to deliver a Guaranteed QoS when required (although we are recommending that all of our pods and containers use the Burstable QoS) As part of this we would like to ask you to do several things:

1. consider which of your pods/containers you would like to expose for
scaling properties for for both horizontal (deployment replicas) and vertical (mem/cpu request/limits).

2. expose said configuration properties.

3. sets mem and cpu values for all containers in order to provide as much meta-data to the k8s as possible so that its scheduler can do as good a job as possible. This PR is an initial attempt at setting these values, although we know you are much more likely to have insight into your components mem/cpu requirements than our guess.

If you have any questions or concerns, please let us know! Thanks!

[#174462927](https://www.pivotaltracker.com/story/show/174462927)

Co-Authored-By: Angela Chin <achin@pivotal.io>