### PR TITLE
Add permissions to access with eirini-events

### DIFF
--- a/helm/eirini/templates/events-service-account.yml
+++ b/helm/eirini/templates/events-service-account.yml
@@ -7,6 +7,48 @@ metadata:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eirini-events
+  namespace: {{ .Values.opi.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eirini-events
+  namespace: {{ .Values.opi.namespace }}
+roleRef:
+  kind: Role
+  name: eirini-events
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: eirini-events
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eirini-events-clusterrole
@@ -102,15 +144,29 @@ spec:
   readOnlyRootFilesystem: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: eirini-events-policy
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "events"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: eirini-events-nodes-policy
+  name: eirini-events
 subjects:
 - kind: ServiceAccount
   name: eirini-events
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: eirini-nodes-policy
+  name: eirini-events-policy
   apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
See eirini issue https://github.com/cloudfoundry-incubator/eirini/issues/100
for details: crash events currently aren't reported to capi

[##173293404](https://www.pivotaltracker.com/story/show/#173293404)

Co-authored-by: Andrew Costa <acosta@pivotal.io>

We aren't 100% sure, but we think the old code at the end of the diff, in the final `ClusterRoleBinding` was referring to nodes instead of events due to a copy/paste typo

Thanks for contributing to Eirini! In order for your pull request to be accepted, we would like to ask you the following:

[x] 1. Please base your PR off the `develop` branch.

1. Describe the change on a conceptual level. How does it work, and why should it exist? Ideally, you contribute a few words to the README, too.

[x] Crashed app events do not show up in `cf events APP`. We had this working, but after upgrading to eirini 1.8.0 the feature stopped working.

1. Please provide automated tests (preferred) or instructions for manually testing your change.

In window 1:
```
git clone https://github.com/cloudfoundry/cf-acceptance-tests.git
cd cf-acceptance-tests
git co develop
git pull
cf push catnip -p assets/catnip 
curl -k https://catnip.apps.DOMAIN/
```

In window 2:
```
kubectl logs -n  cf-system eirini-events-SUFFIX -c event-reporter -f
```

Back in window 1:
```
curl -k https://catnip.apps.DOMAIN/sigterm/KILL
# You should see some output like:
# upstream connect error or disconnect/reset before headers. reset reason: connection failure* Closing connection 0
cf events catnip
# At the top of the list you should see output like
# Getting events for app catnip in org org / space space as admin...
time                          event                       actor             description
2020-09-01T14:01:23.00-0700   app.crash                   catnip            index: 0, reason: Error, cell_id: , instance: catnip-space-950478d148-0, exit_description: Error, exit_status: 1
```

In window 2, you should see with recent timestamps and text like
`"source":"instance-crash-reporter","message":"instance-crash-reporter.cc-client.delivering-app-crashed-response","data":{"app_crashed":{"instance":"catnip-space-950478d148-0",`
