### PR TITLE
Fix yamls after eirini bump

### DIFF
--- a/deploy/core/instance-index-env-injector.yml
+++ b/deploy/core/instance-index-env-injector.yml
@@ -48,7 +48,7 @@ metadata:
   namespace: eirini-core
 spec:
   ports:
-    - port: 443
+    - port: 8443
       targetPort: 8443
       protocol: TCP
       name: https

--- a/helm/eirini/templates/instance-index-env-injector.yml
+++ b/helm/eirini/templates/instance-index-env-injector.yml
@@ -52,7 +52,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-    - port: 443
+    - port: 8443
       targetPort: 8443
       protocol: TCP
       name: https


### PR DESCRIPTION
Use the correct svc port for env injector.
    
After bumping eirinix (https://github.com/cloudfoundry-incubator/eirini/commit/ea0b5ea9a70f59ab499514be038f3e5421b5cf8b)
now the Port setting on the Manager config works as expected:
    
https://github.com/cloudfoundry-incubator/eirini/blob/master/cmd/instance-index-env-injector/main.go#L37
    
thus the kube api was trying to access our webhook on a service
listening on port 8443, while our service was listening on port 443 instead.
 
This should fix CI errors: https://jetson.eirini.cf-app.com/teams/main/pipelines/ci/jobs/run-eats-tests-monaco/builds/41
