### PR TITLE
cf: Do not fail when router count is not defined

### DIFF
--- a/helm/cf/templates/pdb.yml
+++ b/helm/cf/templates/pdb.yml
@@ -1,4 +1,5 @@
-{{- if and (hasKey .Values.sizing.router "count" ) ( gt .Values.sizing.router.count 1.0 ) }}
+{{- if hasKey .Values.sizing.router "count" }}
+{{- if gt .Values.sizing.router.count 1.0 }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -9,4 +10,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: "router"
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Operator "and" always evaluates all parameters thus the original expression fails if `count` is not defined.
The error message is `error calling gt: invalid type for comparison`.

Fixing with a nested "if".

See https://stackoverflow.com/a/59796677