### PR TITLE
cf: Do not fail when router count is not defined

### DIFF
--- a/helm/cf/templates/pdb.yml
+++ b/helm/cf/templates/pdb.yml
@@ -1,4 +1,4 @@
-{{- if hasKey .Values.sizing.router "count" }}
+{{- if ne (typeOf .Values.sizing.router.count) "<nil>" }}
 {{- if gt .Values.sizing.router.count 1.0 }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget


### PR DESCRIPTION
This is a follow up for https://github.com/cloudfoundry-incubator/eirini-release/pull/179

Turns out `Values.sizing.router` always has the key `count` however the value is <nil> if count is not defined. Therefore the check has to be if it's nil.