### PR TITLE
Update event-reporter-rbac for Kubernetes 1.22

### DIFF
--- a/helm/templates/events/event-reporter-rbac.yml
+++ b/helm/templates/events/event-reporter-rbac.yml
@@ -98,7 +98,7 @@ spec:
   readOnlyRootFilesystem: false
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eirini-event-reporter-nodes-policy
@@ -112,7 +112,7 @@ rules:
   - "get"
   - "list"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eirini-event-reporter-nodes-policy


### PR DESCRIPTION
- `rbac.authorization.k8s.io/v1beta1` -> `rbac.authorization.k8s.io/v1`
- [Removed v1beta1 API in Kubernetes
1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122)
